### PR TITLE
Only run CI on pushes to main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,10 @@
 name: GD-Posix-Apps Build/test CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
 
 jobs:
   linux-build:


### PR DESCRIPTION
This prevents us running CI twice on Pull Requests.  Once for the push
and once for the PR

If I want to run checks on a branch I can always create a draft PR.